### PR TITLE
Responsive fix

### DIFF
--- a/snet-ui/FlipClock/style.module.css
+++ b/snet-ui/FlipClock/style.module.css
@@ -35,7 +35,7 @@
 }
 .upperCard span,
 .lowerCard span {
-  font-size: 4em;
+  font-size: 2.5em;
   font-family: "Montserrat";
   font-weight: lighter;
   color: "primary.main";
@@ -75,7 +75,7 @@
 }
 .flipCard span {
   font-family: "Montserrat";
-  font-size: 4em;
+  font-size: 2.5em;
   font-weight: lighter;
   color:"primary.main";
 }

--- a/snet-ui/Header/DrawerComponent.tsx
+++ b/snet-ui/Header/DrawerComponent.tsx
@@ -100,6 +100,13 @@ const DrawerComponent =({
                   setOpen={handleUserMenuClose}
                   changeAccount={onConnectWallet}
                 />
+                             <IconButton className={classes.drawerIcon} onClick={() => setOpenDrawer(!openDrawer)}>
+                <div className={classes.hamburger}>
+                    <span />
+                    <span />
+                    <span />
+                </div>
+            </IconButton>
               </>
             ) : (
               <Button
@@ -111,13 +118,7 @@ const DrawerComponent =({
                 Connect Wallet
               </Button>
             )}
-            <IconButton className={classes.drawerIcon} onClick={() => setOpenDrawer(!openDrawer)}>
-                <div className={classes.hamburger}>
-                    <span />
-                    <span />
-                    <span />
-                </div>
-            </IconButton>
+
       </div>
       
     </>


### PR DESCRIPTION
Show the hamburger lines ONLY When the wallet is connected
The font size of the timer has been reduced to be more response